### PR TITLE
Removing http weather API

### DIFF
--- a/views/events/show.ejs
+++ b/views/events/show.ejs
@@ -63,10 +63,6 @@
                     <td scope="row" class="mdl-data-table__cell--non-numeric">Description</td>
                     <td><%= event.description %></td>
                   </tr>
-                  <tr>
-                    <td scope="row" class="mdl-data-table__cell--non-numeric">Weather</td>
-                    <td> <p id = "weather"> </p>  </td>
-                  </tr>
                 </tbody>
               </table>
               <div class="mdl-row">


### PR DESCRIPTION
Removed weather from HTML as http weather API and https Google Maps API can't be used together