### PR TITLE
Remove unused weather logic

### DIFF
--- a/public/javascript/interface.js
+++ b/public/javascript/interface.js
@@ -18,12 +18,6 @@ $(document).ready(function() {
     setEventDate();
   }
 
-
-  if (document.getElementById("weather")) {
-    displayWeather();
-  }
-
-
   $(".clickable-row").click(function() {
     window.location = $(this).data("href");
   });
@@ -241,16 +235,4 @@ $(document).ready(function() {
 
   }
 
-  function displayWeather() {
-    var url = 'http://api.openweathermap.org/data/2.5/weather?q=';
-    var apiKey = "&apikey=1235658b8e5f2613a1e72f249e6efe3a";
-    var units = '&units=metric';
-    var city = document.getElementById("location").innerText;
-    $.get(url + city + apiKey + units, function(data) {
-      var icon = data.weather[0].icon
-      var temp = Math.round(data.main.temp)
-      $('#weather').html(' ' + temp +' ºC');
-      $('#weather').prepend($('<img>',{id:'theImg',src:'https://openweathermap.org/img/w/'+ icon + '.png'}));
-    });
-  }
 });


### PR DESCRIPTION
In a [previous commit](https://github.com/peter-miklos/plyr2/commit/8e8e4f893dc7b7bb12005c1668bf4a47f3da107d) I only removed the HTML element displaying the weather. I forgot to also remove the logic for displaying it, which currently isn't being used.

If anyone is against it, I'm happy for us to add a different HTTPS weather API (to fix the mixed content error we had when using it with the Heroku HTTPS site) in the future. We have the commit history to know how to add a new one, but for now I think this dead code should be deleted.